### PR TITLE
🐛Fix an icon RegExp bug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,19 +33,19 @@ async function replace_response_text(response) {
   // text = text.replace(re4, l);
   // replace icon
   let re3 = new RegExp(
-    'data-content=\\\\".\\\\"><img src=\\\\".*?"><\\\\?/i>',
+    'data-content=\\\\".*?\\\\"><img src=\\\\".*?"><\\\\?/i>',
     'g',
   )
   text = text.replace(
     re3,
-    '<i class=\\"tgme_widget_message_user_photo bgcolor1\\" data-content=\\"i\\"><img src=\\"' +
+    'class=\\"tgme_widget_message_user_photo bgcolor1\\" data-content=\\"i\\"><img src=\\"' +
       icon_url +
       '\\"></i>',
   )
-  let re4 = new RegExp('data-content="."><img src=".*?"><\\/i>', 'g')
+  let re4 = new RegExp('data-content=".*?"><img src=".*?"><\\/i>', 'g')
   text = text.replace(
     re4,
-    '<i class="tgme_widget_message_user_photo bgcolor1" data-content="i"><img src="' +
+    'class="tgme_widget_message_user_photo bgcolor1" data-content="i"><img src="' +
       icon_url +
       '"></i>',
   )


### PR DESCRIPTION
修复了一下 icon 正则匹配的问题。

一个是我这边的 telegram 预览中部分 icon 的 `data-content` 属性为 `MB`，原代码中匹配单字符就不适用了，于是修改为了匹配多字符。

![图片](https://user-images.githubusercontent.com/41962043/80130609-7837ce80-85cb-11ea-8aaa-25654fe0f2a4.png)


还有一个是匹配再 replace 之后多了 `<i`，如下图所示。（虽然在这里没有影响浏览器解析，但还是正确闭合比较好吧

![图片](https://user-images.githubusercontent.com/41962043/80129828-39554900-85ca-11ea-95b6-804c10162225.png)



